### PR TITLE
Improve reporting

### DIFF
--- a/client.go
+++ b/client.go
@@ -52,7 +52,7 @@ func (stats *clientStats) Render(w io.Writer) error {
 
 	fmt.Fprintf(w, "\n   Requests:   %0.2f per second", rps)
 	if stats.numErrors > 0 && stats.numErrors != stats.numTotal {
-		errAvg := stats.timeErrors / time.Duration(stats.numErrors)
+		errAvg := float64(stats.numErrors) / stats.timeErrors.Seconds()
 		fmt.Fprintf(w, ", %0.2f per second for errors", errAvg)
 	}
 

--- a/histogram.go
+++ b/histogram.go
@@ -1,0 +1,72 @@
+package main
+
+import "sort"
+
+// TODO: Replace histogram implementation with a sparse bucket based one so
+// it's memory-bounded.
+
+type histogram struct {
+	all   []float64
+	min   float64
+	max   float64
+	total float64
+}
+
+func (h *histogram) Add(point float64) {
+	h.all = append(h.all, point)
+	h.total += point
+	if len(h.all) == 1 || h.min > point {
+		h.min = point
+	}
+	if h.max < point {
+		h.max = point
+	}
+}
+
+func (h *histogram) Total() float64 {
+	return h.total
+}
+
+func (h *histogram) Min() float64 {
+	return h.min
+}
+
+func (h *histogram) Max() float64 {
+	return h.max
+}
+
+func (h *histogram) Average() float64 {
+	return h.total / float64(len(h.all))
+}
+
+func (h *histogram) Len() int {
+	return len(h.all)
+}
+
+// Percentiles takes buckets in whole percentages (e.g. 95 is 95%) and returns
+// a slice with percentile values in the corresponding index. Buckets must be
+// in-order.
+func (h *histogram) Percentiles(buckets ...int) []float64 {
+	r := make([]float64, len(buckets))
+	if len(h.all) == 0 {
+		return r
+	}
+
+	sort.Float64s(h.all)
+
+	for i, j := 0, 0; i < len(h.all) || j < len(buckets); i++ {
+		if i >= len(h.all) {
+			// Fill up the remaining buckets with the highest value.
+			r[j] = h.all[len(h.all)-1]
+			j++
+			continue
+		}
+
+		current := i * 100 / len(h.all)
+		if current >= buckets[j] {
+			r[j] = h.all[i]
+			j++
+		}
+	}
+	return r
+}

--- a/histogram.go
+++ b/histogram.go
@@ -67,6 +67,10 @@ func (h *histogram) Percentiles(buckets ...int) []float64 {
 			r[j] = h.all[i]
 			j++
 		}
+
+		if j >= len(buckets) {
+			break
+		}
 	}
 	return r
 }

--- a/histogram_test.go
+++ b/histogram_test.go
@@ -1,0 +1,38 @@
+package main
+
+import "testing"
+
+func TestHistogram(t *testing.T) {
+	h := histogram{}
+
+	for i := 1; i <= 1000; i++ {
+		h.Add(float64(i))
+	}
+
+	if got, want := h.Total(), 500500.0; got != want {
+		t.Errorf("got: %0.4f; want: %0.4f", got, want)
+	}
+	if got, want := h.Average(), 500.5; got != want {
+		t.Errorf("got: %0.4f; want: %0.4f", got, want)
+	}
+	if got, want := h.Min(), 1.0; got != want {
+		t.Errorf("got: %0.4f; want: %0.4f", got, want)
+	}
+	if got, want := h.Max(), 1000.0; got != want {
+		t.Errorf("got: %0.4f; want: %0.4f", got, want)
+	}
+
+	percentiles := h.Percentiles(5, 50, 99, 100)
+	if got, want := percentiles[0], 51.0; got != want {
+		t.Errorf("got: %0.4f; want: %0.4f", got, want)
+	}
+	if got, want := percentiles[1], 501.0; got != want {
+		t.Errorf("got: %0.4f; want: %0.4f", got, want)
+	}
+	if got, want := percentiles[2], 991.0; got != want {
+		t.Errorf("got: %0.4f; want: %0.4f", got, want)
+	}
+	if got, want := percentiles[3], 1000.0; got != want {
+		t.Errorf("got: %0.4f; want: %0.4f", got, want)
+	}
+}

--- a/main.go
+++ b/main.go
@@ -30,6 +30,11 @@ type Options struct {
 
 	//Source      string `long:"source" description:"Where to get requests from (options: stdin-jsons, ethspam)" default:"stdin-jsons"` // Someday: stdin-tcpdump, file://foo.json, ws://remote-endpoint
 
+	// TODO: Specify additional headers/configs per-endpoint (e.g. auth headers)
+	// TODO: Periodic reporting for long-running tests?
+	// TODO: Toggle compare results? Could probably reach higher throughput without result comparison.
+	// TODO: Add latency offcheck set before starting
+
 	Verbose []bool `long:"verbose" short:"v" description:"Show verbose logging."`
 	Version bool   `long:"version" description:"Print version and exit."`
 }

--- a/main.go
+++ b/main.go
@@ -151,7 +151,7 @@ func run(ctx context.Context, options Options) error {
 
 	if len(options.Verbose) > 0 {
 		r.MismatchedResponse = func(resps []Response) {
-			logger.Info().Msgf("mismatched responses: %s", Responses(resps).String())
+			logger.Info().Int("id", int(resps[0].ID)).Msgf("mismatched responses: %s", Responses(resps).String())
 		}
 	}
 

--- a/report.go
+++ b/report.go
@@ -40,7 +40,7 @@ func (r *report) Render(w io.Writer) error {
 	fmt.Fprintf(w, "\n** Summary for %d endpoints:\n", len(r.Clients))
 	fmt.Fprintf(w, "   Completed:  %d results with %d total requests\n", r.completed, r.requests)
 	if r.requests > 0 {
-		fmt.Fprintf(w, "   Elapsed:    %s request avg, %s total run time\n", r.elapsed/time.Duration(r.requests), time.Now().Sub(r.started))
+		fmt.Fprintf(w, "   Timing:     %s request avg, %s total run time\n", r.elapsed/time.Duration(r.requests), time.Now().Sub(r.started))
 		fmt.Fprintf(w, "   Errors:     %d (%0.2f%%)\n", r.errors, float64(r.errors*100)/float64(r.requests))
 	}
 	fmt.Fprintf(w, "   Mismatched: %d\n", r.mismatched)

--- a/report.go
+++ b/report.go
@@ -96,7 +96,12 @@ func (r *report) compareResponses(resp Response) {
 		}
 	}
 
-	logger.Debug().Int("id", int(resp.ID)).Int("mismatched", r.mismatched).Durs("ms", durations).Err(resp.Err).Msg("result")
+	// TODO: Check for JSONRPC error objects?
+
+	l := logger.Debug().Int("id", int(resp.ID)).Int("mismatched", r.mismatched).Durs("ms", durations).Err(resp.Err)
+	// For super-debugging:
+	// l = l.Bytes("req", resp.Request.Line).Bytes("resp", resp.Body)
+	l.Msg("result")
 }
 
 func (r *report) handle(resp Response) error {

--- a/transport.go
+++ b/transport.go
@@ -32,6 +32,7 @@ func NewTransport(endpoint string, timeout time.Duration) (Transport, error) {
 
 type Transport interface {
 	// TODO: Add context?
+	// TODO: Should this be: Do(Request) (Response, error)?
 	Send(body []byte) ([]byte, error)
 }
 


### PR DESCRIPTION
- Added a bunch of TODOs for later
- Added histogram implementation with percentiles
- Revamped report output
- Switched to seconds for endpoint reporting, rather than duration-native units. Not sure if I'm happy with this.
- Percentile needs more testing, I worry there's an off-by-one error there.

Latest output:

```
Endpoints:

0. "https://shazow.net/"

   Requests:   25.51 per second
   Timing:     0.0392s avg, 0.0065s min, 1.0279s max

   Percentiles:
     25% in 0.0090s
     50% in 0.0100s
     75% in 0.0116s
     90% in 0.0152s
     95% in 0.3767s
     99% in 1.0279s

   Errors: 100.00%
     100 × "bad status code: 405"

** Summary for 1 endpoints:
   Completed:  100 results with 100 total requests
   Timing:     39.200052ms request avg, 1.413239503s total run time
   Errors:     100 (100.00%)
   Mismatched: 0
```