### PR TITLE
Add latency estimation to reporting

### DIFF
--- a/latency.go
+++ b/latency.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptrace"
+	"time"
+)
+
+var latencyTimeout = 2 * time.Second
+var latencySamples = 5
+
+type latencyResult struct {
+	Latency time.Duration
+	Err     error
+}
+
+// HTTPLatency sends sample number of concurrent HEAD requests to the domain of
+// the endpoint and returns the lowest response time. This is approximately the
+// latency of the server.
+func HTTPLatency(endpoint string) (time.Duration, error) {
+	resCh := make(chan latencyResult, latencySamples)
+	for i := 0; i < latencySamples; i++ {
+		go func() {
+			var start time.Time
+			var elapsed time.Duration
+			trace := &httptrace.ClientTrace{
+				GotFirstResponseByte: func() {
+					elapsed = time.Now().Sub(start)
+				},
+				GetConn: func(string) {
+					if start.IsZero() {
+						start = time.Now()
+					}
+				},
+			}
+			req, err := http.NewRequest("HEAD", endpoint, nil)
+			if err != nil {
+				resCh <- latencyResult{
+					Err: err,
+				}
+				return
+			}
+			ctx, cancel := context.WithTimeout(req.Context(), latencyTimeout)
+			defer cancel()
+			req = req.WithContext(httptrace.WithClientTrace(ctx, trace))
+			resp, err := http.DefaultTransport.RoundTrip(req)
+			defer resp.Body.Close()
+			resCh <- latencyResult{
+				Latency: elapsed,
+				Err:     err,
+			}
+		}()
+	}
+	var minLatency time.Duration = latencyTimeout
+	var lastErr error
+	for i := 0; i < latencySamples; i++ {
+		res := <-resCh
+		if res.Err != nil {
+			lastErr = res.Err
+		} else if minLatency > res.Latency {
+			minLatency = res.Latency
+		}
+	}
+	return minLatency, lastErr
+}

--- a/main.go
+++ b/main.go
@@ -25,7 +25,7 @@ type Options struct {
 	} `positional-args:"yes"`
 
 	Timeout     string `long:"timeout" description:"Abort request after duration" default:"30s"`
-	StopAfter   string `long:"stop-after" description:"Stop after N requests per endpoint, N can be a number or duration."`
+	StopAfter   string `long:"stop-after" description:"Stop after N requests per endpoint, N can be a number or duration"`
 	Concurrency int    `long:"concurrency" description:"Concurrent requests per endpoint" default:"1"`
 	//CompareResponse string `long:"compare-response" description:"Load all response bodies and compare between endpoints, will affect throughput." default:"on"`
 
@@ -36,6 +36,7 @@ type Options struct {
 	// TODO: Toggle compare results? Could probably reach higher throughput without result comparison.
 	// TODO: Add latency offcheck set before starting
 
+	//Latency bool   `long:"latency" description:"Attempt to measure endpoint latency separately by HEAD'ing the domain"`
 	Verbose []bool `long:"verbose" short:"v" description:"Show verbose logging."`
 	Version bool   `long:"version" description:"Print version and exit."`
 }


### PR DESCRIPTION
If random people are going to be running this against random endpoints all over the world, it's important to account for the relative latency between the benchmarker and the endpoint. Ideally we'd only want to measure how long a request takes regardless of geographical location, but I can't figure out a reliable way to do this.

Some strategies I tried:
- Would be nice to just use ping, but every meaningful endpoint I tried blocks ICMP. RIP ping.
- Do a bunch of HEAD requests (which are hopefully approximately no-op on the edge router) and take the fastest to approximate ping. In practice, the results were surprisingly high here but I'm not accounting for connection creation and who knows what's happening behind the edge router. The `HTTPLatency` helper for this still exists but it's unused at the moment. (There's room to improve the current implementation but not sure this is the best direction anyway.)
- The one I settled on is trying to measure the segment of the request from when the connection is requested to the time the first byte is written, and taking the minimum of that per endpoint across the whole benchmark. Basically the fastest response across the benchmark (not including the time to write the response) is the latency baseline.
- *Update*: Maybe I should skip pretending to know the latency and instead add some reporting about the variance between the min and max timing?

Is this reasonable? Is it misleading? Is there a better way to do this?

The output looks like this ("Latency" line added per endpoint)

```
0. "https://bar.provider/"

   Latency:    0.0430s (included in timing)
   Requests:   20.52 per second
   Timing:     0.0975s avg, 0.0432s min, 0.2543s max

   Percentiles:
     25% in 0.0491s
     50% in 0.0644s
     75% in 0.2528s
     90% in 0.2543s
     95% in 0.2543s
     99% in 0.2543s

   Errors: 0.00%

1. "https://foo.provider/"

   Latency:    0.0773s (included in timing)
   Requests:   14.35 per second
   Timing:     0.1394s avg, 0.0761s min, 0.2962s max

   Percentiles:
     25% in 0.0901s
     50% in 0.0916s
     75% in 0.2856s
     90% in 0.2962s
     95% in 0.2962s
     99% in 0.2962s

   Errors: 0.00%

** Summary for 2 endpoints:
   Completed:  10 results with 20 total requests
   Timing:     118.411709ms request avg, 1.072134015s total run time
   Errors:     0 (0.00%)
   Mismatched: 3
```