### PR TITLE
Add standard deviation to timing reporting

### DIFF
--- a/client.go
+++ b/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math"
 	"sync"
 	"time"
 
@@ -60,8 +61,12 @@ func (stats *clientStats) Render(w io.Writer) error {
 		fmt.Fprintf(w, ", %0.2f per second for errors", errAvg)
 	}
 
+	variance := stats.timing.Variance()
+	stddev := math.Sqrt(variance)
+
 	fmt.Fprintf(w, "\n")
 	fmt.Fprintf(w, "   Timing:     %0.4fs avg, %0.4fs min, %0.4fs max\n", stats.timing.Average(), stats.timing.Min(), stats.timing.Max())
+	fmt.Fprintf(w, "               %0.4fs standard deviation\n", stddev)
 
 	fmt.Fprintf(w, "\n   Percentiles:\n")
 	buckets := []int{25, 50, 75, 90, 95, 99}

--- a/histogram.go
+++ b/histogram.go
@@ -39,6 +39,17 @@ func (h *histogram) Average() float64 {
 	return h.total / float64(len(h.all))
 }
 
+func (h *histogram) Variance() float64 {
+	// Population variance
+	mean := h.Average()
+	sum := 0.0
+	for _, v := range h.all {
+		delta := v - mean
+		sum += delta * delta
+	}
+	return sum / float64(h.Len())
+}
+
 func (h *histogram) Len() int {
 	return len(h.all)
 }

--- a/histogram_test.go
+++ b/histogram_test.go
@@ -36,3 +36,16 @@ func TestHistogram(t *testing.T) {
 		t.Errorf("got: %0.4f; want: %0.4f", got, want)
 	}
 }
+
+func TestHistogramVariance(t *testing.T) {
+	h := histogram{}
+	h.Add(5)
+	h.Add(6)
+	h.Add(7)
+	h.Add(8)
+	h.Add(9)
+
+	if got, want := h.Variance(), 2.; got != want {
+		t.Errorf("got: %0.4f; want: %0.4f", got, want)
+	}
+}


### PR DESCRIPTION
Added standard deviation to timing, this seems more representative of the variance between the min and max timing, and probably more informative for benchmarking.

Looks like this:

```
Endpoints:

0. "https://foo.provider/"

   Requests:   67.03 per second
   Timing:     0.0746s avg, 0.0395s min, 0.2914s max
               0.0568s standard deviation

   Percentiles:
     25% in 0.0446s
     50% in 0.0489s
     75% in 0.0733s
     90% in 0.1466s
     95% in 0.2230s
     99% in 0.2914s

   Errors: 0.00%

1. "https://bar.provider/

   Requests:   53.55 per second
   Timing:     0.0934s avg, 0.0535s min, 0.5858s max
               0.0709s standard deviation

   Percentiles:
     25% in 0.0677s
     50% in 0.0724s
     75% in 0.0812s
     90% in 0.1284s
     95% in 0.2662s
     99% in 0.5858s

   Errors: 0.00%

** Summary for 2 endpoints:
   Completed:  100 results with 200 total requests
   Timing:     83.985424ms request avg, 2.253833378s total run time
   Errors:     0 (0.00%)
   Mismatched: 19
```